### PR TITLE
change paragraph font to Satoshi

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,9 +13,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400&display=swap" rel="stylesheet">
+  <link href="https://api.fontshare.com/v2/css?f[]=satoshi@300&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
     integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
     crossorigin="" />

--- a/src/App.scss
+++ b/src/App.scss
@@ -18,7 +18,7 @@
 
 input,
 textarea {
-  font-family: 'Roboto', sans-serif;
+  font-family: 'Satoshi', sans-serif;
 }
 
 .loader-active {

--- a/src/components/Contact/index.scss
+++ b/src/components/Contact/index.scss
@@ -39,7 +39,7 @@
     background: black;
     height: 50px;
     font-size: 16px;
-    font-family: 'Roboto', sans-serif;
+    font-family: 'Satoshi', sans-serif;
     color: #fff;
     padding: 0 20px;
     box-sizing: border-box;
@@ -55,7 +55,7 @@
     background: black;
     height: 50px;
     font-size: 16px;
-    font-family: 'Roboto', sans-serif;
+    font-family: 'Satoshi', sans-serif;
     color: #fff;
     padding: 20px;
     box-sizing: border-box;
@@ -69,7 +69,7 @@
   .flat-button {
     color: #64cccd;
     font-size: 11px;
-    font-family: 'Roboto', sans-serif;
+    font-family: 'Satoshi', sans-serif;
     letter-spacing: 3px;
     text-decoration: none;
     padding: 8px 10px;
@@ -128,7 +128,7 @@
   width: 267px;
   padding: 20px;
   color: #fff;
-  font-family: 'Roboto';
+  font-family: 'Satoshi';
   font-size: 17px;
   font-weight: 300;
   opacity: 0;
@@ -175,7 +175,7 @@
     background: black;
     margin-top: 50%;
     margin-right: 15%;
-    font-family: 'Roboto';
+    font-family: 'Satoshi';
     font-size: 12px;
     font-weight: 300;
     width: auto;

--- a/src/components/Layout/index.scss
+++ b/src/components/Layout/index.scss
@@ -125,7 +125,7 @@
     p {
       font-size: 15px;
       color: #fff;
-      font-family: 'Roboto', sans-serif;
+      font-family: 'Satoshi', sans-serif;
       font-weight: 300;
       max-width: fit-content;
       animation: pulse 1s;

--- a/src/components/Sidebar/index.scss
+++ b/src/components/Sidebar/index.scss
@@ -81,7 +81,7 @@
 
       &:after {
         content: '';
-        font-family: 'Roboto', sans-serif !important;
+        font-family: 'Satoshi', sans-serif !important;
         font-size: 9px;
         letter-spacing: 2px;
         position: absolute;

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@ html {
 
 body {
   margin: 0;
-  font-family: 'Roboto', sans-serif;
+  font-family: 'Satoshi', sans-serif;
   font-weight: 300;
   font-size: 11px;
   line-height: 1.4;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only typography change that swaps the default font source and updates SCSS font-family declarations; main risk is minor visual/layout shifts or reliance on a third-party font CDN.
> 
> **Overview**
> Switches the app’s default typography from `Roboto` to `Satoshi`.
> 
> Replaces the Google Fonts `Roboto` includes in `public/index.html` with a Fontshare `Satoshi` stylesheet, and updates `font-family` declarations across global styles and key components (`src/index.css`, `App.scss`, `Contact`, `Layout`, `Sidebar`) to use `Satoshi`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f017e547d7e3a1d358aa287c9ad6c73b8bbf23d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->